### PR TITLE
add video links to 2019 GAGE short course

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ MintPy-tutorials contains the documentations for the [MintPy repo](https://githu
 1. Small baseline time series analysis with `smallbaselineApp`. This notebook walks through the various processing steps of InSAR time series analysis using MintPy.     
 
    - ISCE/topsStack + MintPy (Sentinel-1 on Fernandina, Galápagos): [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/smallbaselineApp.ipynb)
-   - ARIA + MintPy (Sentinel-1 on San Francisco): [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/smallbaselineApp_aria.ipynb)
+   - ARIA + MintPy (Sentinel-1 on San Francisco Bay): [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/smallbaselineApp_aria.ipynb) [[video](https://youtu.be/lRFDSsi8ZcY?t=10933)]
 
 2. Visualizations   
 
@@ -30,9 +30,8 @@ MintPy-tutorials contains the documentations for the [MintPy repo](https://githu
 
 4. Custom applications. List of examples of how to build customized application using mintpy modules or to build processing recipe using mintpy scripts.     
 
-   - Calculate multilook number for InSAR processing with ISCE: [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/applications/calc_multilook_number.ipynb)
    - Create water mask in radar coordinates: [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/applications/water_mask.ipynb)
-   - Tropospheric delay correction using GACOS products: [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/applications/tropo_gacos.ipynb)
+   - Calculate multilook number for InSAR processing with ISCE: [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/applications/calc_multilook_number.ipynb)
    - Post-processing of single interferogram after ISCE/stripmapApp: [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/applications/stripmapApp_postProc.ipynb)
    - Geo / radar coordinates conversion: [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/applications/coord_conversion.ipynb)
    - Plot GPS as quiver on top of InSAR data: [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/applications/plot_gps_quiver.ipynb)
@@ -42,15 +41,15 @@ MintPy-tutorials contains the documentations for the [MintPy repo](https://githu
 
 1. Single interferogram processing with [ISCE2](https://github.com/isce-framework/isce2-docs/tree/master/Notebooks)
 
-   - Sentinel-1 TOPS mode SAR data with [topsApp](https://nbviewer.jupyter.org/github/isce-framework/isce2-docs/blob/master/Notebooks/UNAVCO_2020/TOPS/topsApp.ipynb)
-   - StripMap mode SAR data with [stripmapApp](https://nbviewer.jupyter.org/github/isce-framework/isce2-docs/blob/master/Notebooks/UNAVCO_2020/Stripmap/stripmapApp.ipynb)
+   - Sentinel-1 TOPS mode SAR data with [topsApp](https://nbviewer.jupyter.org/github/isce-framework/isce2-docs/blob/master/Notebooks/UNAVCO_2020/TOPS/topsApp.ipynb) [[video](https://youtu.be/V0CFy0i1L80?t=5509)]
+   - StripMap mode SAR data with [stripmapApp](https://nbviewer.jupyter.org/github/isce-framework/isce2-docs/blob/master/Notebooks/UNAVCO_2020/Stripmap/stripmapApp.ipynb) [[video](https://youtu.be/Q8sqCN4qfE4?t=7370)]
 
-2. Stack of interferograms processing with [ISCE2 stack processors](https://github.com/isce-framework/isce2/blob/main/contrib/stack/README.md)
+2. Stack of interferograms processing with [ISCE2 stack processors](https://github.com/isce-framework/isce2/blob/main/contrib/stack/README.md) [[video](https://youtu.be/oc_rMjICnyI?t=1396)]
 
    - Sentinel-1 TOPS mode SAR data with [topsStack](https://github.com/isce-framework/isce2/blob/main/contrib/stack/topsStack/README.md)
    - StripMap mode SAR data with [stripmapStack](https://github.com/isce-framework/isce2/blob/main/contrib/stack/stripmapStack/README.md)
 
-3. Manipulate ARIA standard InSAR products with [ARIA-tools](https://github.com/aria-tools/ARIA-tools-docs)
+3. Manipulate ARIA standard InSAR products with [ARIA-tools](https://github.com/aria-tools/ARIA-tools-docs) [[video](https://youtu.be/lRFDSsi8ZcY)]
 
    - Downloading GUNW products using [ariaDownload](https://nbviewer.jupyter.org/github/aria-tools/ARIA-tools-docs/blob/master/JupyterDocs/ariaDownload/ariaDownload_tutorial.ipynb)
    - Preparing GUNW products for time series analysis using [ariaTSsetup](https://nbviewer.jupyter.org/github/aria-tools/ARIA-tools-docs/blob/master/JupyterDocs/ariaTSsetup/ariaTSsetup_tutorial.ipynb)


### PR DESCRIPTION
+ add video links at YouTube for the 2019 short course
+ remove link for gacos notebook since it's not supported directly via prep_gacos.py.