### PR TITLE
`smallbaselineApp_gmtsar`: add iono description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MintPy-tutorial
 
-[![Language](https://img.shields.io/badge/python-3.6%2B-blue.svg?style=flat-square)](https://www.python.org/)
+[![Language](https://img.shields.io/badge/python-3.8%2B-blue.svg?style=flat-square)](https://www.python.org/)
 [![License](https://img.shields.io/badge/license-GPLv3+-yellow.svg?style=flat-square)](https://github.com/insarlab/MintPy-tutorial/blob/main/LICENSE)
 [![render](https://img.shields.io/badge/render-nbviewer-orange.svg?style=flat-square)](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/tree/main/)
 [![Citation](https://img.shields.io/badge/doi-10.1016%2Fj.cageo.2019.104331-blue?style=flat-square)](https://doi.org/10.1016/j.cageo.2019.104331)
@@ -14,7 +14,7 @@ MintPy-tutorials contains the documentations for the [MintPy repo](https://githu
 This notebook walks through the various processing steps of InSAR time series analysis using MintPy.     
 
    - ARIA + MintPy (Sentinel-1 on San Francisco Bay, California): [nbviewer](https://nbviewer.jupyter.org/github/insarlab/MintPy-tutorial/blob/main/workflows/smallbaselineApp_aria.ipynb)
-       - [UNAVCO / EarthScope short course](https://www.earthscope.org/event/2023-insar-isce-short-course/) recordings on YouTube: [2019](https://youtu.be/lRFDSsi8ZcY?t=10933), [2020](https://youtu.be/BVdVylW_vVQ), [2021](https://youtu.be/vtJpM54KbKs?t=3117), [2022](https://youtu.be/QQxIY4gFHbI?t=4466), [2023](https://youtu.be/Qyj1-UMMWWc?si=BHwx8Llxv2_MtYYP&t=3458), [2024](https://youtu.be/-svj_B_yJyI?si=ImXCshCjjaRxV-yl&t=3051)
+       - [EarthScope InSAR short course](https://www.earthscope.org/event/2023-insar-isce-short-course/) recordings on YouTube: [2019](https://youtu.be/lRFDSsi8ZcY?t=10933), [2020](https://youtu.be/BVdVylW_vVQ), [2021](https://youtu.be/vtJpM54KbKs?t=3117), [2022](https://youtu.be/QQxIY4gFHbI?t=4466), [2023](https://youtu.be/Qyj1-UMMWWc?si=BHwx8Llxv2_MtYYP&t=3458), [2024](https://youtu.be/-svj_B_yJyI?si=ImXCshCjjaRxV-yl&t=3051)
 
 #### 2. Visualizations   
 

--- a/workflows/smallbaselineApp_gmtsar.ipynb
+++ b/workflows/smallbaselineApp_gmtsar.ipynb
@@ -1403,6 +1403,10 @@
     "+ Generic Atmospheric Correction Online Service for InSAR ([GACOS](http://www.gacos.net/)) ([Yu et al., 2018](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2017JB015305))\n",
     "+ Empirical relationship between stratified tropospheric delay and topography ([Doin et al., 2009](https://www.sciencedirect.com/science/article/pii/S0926985109000603)).\n",
     "\n",
+    "<p align='center'>\n",
+    "    <img width=\"800\" src=\"docs/tropo_jolivet14.jpg\">\n",
+    "</p>\n",
+    "\n",
     "The corresponding template options are:\n",
     "\n",
     "```cfg\n",
@@ -1437,13 +1441,53 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2.2 Ionospheric delay correction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This step corrects the ionospheric phase delay. Currently support the range split-spectrum results from [ISCE-2 stack processors](https://github.com/isce-framework/isce2/blob/main/contrib/stack/README.md) only.\n",
+    "+ ISCE-2 topsApp / topsStack ([Liang et al., 2019](https://doi.org/10.1109/TGRS.2019.2908494))\n",
+    "+ ISCE-2 stripmapApp / stripmapStack ([Fattahi et al., 2017](https://doi.org/10.1109/TGRS.2017.2718566))\n",
+    "+ ISCE-2 alos2App / alosStack ([Liang et al., 2018](https://doi.org/10.1109/TGRS.2018.2821150))\n",
+    "\n",
+    "<p align='center'>\n",
+    "    <img width=\"800\" src=\"docs/iono_fattahi17.jpg\">\n",
+    "</p>\n",
+    "\n",
+    "The corresponding template options are:\n",
+    "```cfg\n",
+    "########## 1. load_data\n",
+    "##---------ionosphere stack (optional):\n",
+    "mintpy.load.ionUnwFile      = auto  #[path pattern of unwrapped interferogram files]\n",
+    "mintpy.load.ionCorFile      = auto  #[path pattern of spatial coherence       files]\n",
+    "mintpy.load.ionConnCompFile = auto  #[path pattern of connected components    files], optional but recommended\n",
+    "\n",
+    "########## 7. correct_ionosphere (optional but recommended)\n",
+    "## correct ionospheric delay [need split spectrum results from ISCE-2 stack processors]\n",
+    "mintpy.ionosphericDelay.method        = auto  #[split_spectrum / no], auto for no\n",
+    "mintpy.ionosphericDelay.excludeDate   = auto  #[20080520,20090817 / no], auto for no\n",
+    "mintpy.ionosphericDelay.excludeDate12 = auto  #[20080520_20090817 / no], auto for no\n",
+    "```\n",
+    "\n",
+    "Example `mintpy.load.ion*` values for:\n",
+    "+ ISCE-2/topsStack: [link](https://github.com/insarlab/MintPy/blob/f7ac98f652908063fbdf3cbb1dfca11f822491b5/src/mintpy/defaults/auto_path.py#L26-L28)\n",
+    "+ ISCE-2/alosStack: [link](https://github.com/insarlab/MintPy/blob/f7ac98f652908063fbdf3cbb1dfca11f822491b5/src/mintpy/defaults/auto_path.py#L68-L70)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "heading_collapsed": "true",
     "hideCode": false,
     "hidePrompt": false
    },
    "source": [
-    "### 3.2.2 Solid Earth tides correction"
+    "### 3.2.3 Solid Earth tides correction"
    ]
   },
   {
@@ -1453,7 +1497,13 @@
     "hidePrompt": false
    },
    "source": [
-    "This step corrects the solid Earth tides due to the gravity pull from the Sun and the Moon using [PySolid](https://github.com/insarlab/pysolid) ([Yunjun et al., 2022](https://ieeexplore.ieee.org/document/9759304)), which implements the IERS (International Earth Rotation and Reference Systems Service) 2010 Conventions ([Petit & Luzum, 2010](https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn36.html)).\n",
+    "This step corrects the solid Earth tides ([Xu & Sandwell, 2020](https://doi.org/10.1109/TGRS.2019.2940207)) due to the gravity pull from the Sun and the Moon using [PySolid](https://github.com/insarlab/pysolid) ([Yunjun et al., 2022](https://ieeexplore.ieee.org/document/9759304)), which implements the IERS (International Earth Rotation and Reference Systems Service) 2010 Conventions ([Petit & Luzum, 2010](https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn36.html)).\n",
+    "\n",
+    "<p align='center'>\n",
+    "    <img width=\"800\" src=\"docs/set_yunjun22.png\">\n",
+    "</p>\n",
+    "\n",
+    "The corresponding template options are:\n",
     "\n",
     "```cfg\n",
     "mintpy.solidEarthTides = auto #[yes / no], auto for no\n",
@@ -1464,7 +1514,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2.3 Plate motion"
+    "### 3.2.4 Plate motion"
    ]
   },
   {
@@ -1485,7 +1535,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2.4 Non-closure phase related bias"
+    "### 3.2.5 Non-closure phase related bias"
    ]
   },
   {
@@ -1516,9 +1566,7 @@
     "\n",
     "$$ \\large \\bar{C_n} = \\sum_{k=1}^{K} e^{j C_n^k} \\,/\\, K $$\n",
     "\n",
-    "where $C_n^k$ is the **sequential** closure phase with connection level-$n$ and starting at the $k$-th acquisition, e.g., $C_5^1 = \\Delta\\phi^{1,2} + \\Delta\\phi^{2,3} + \\Delta\\phi^{3,4} + \\Delta\\phi^{4,5} - \\Delta\\phi^{1,5}$. $K$ is the number of available sequential closure phase, $n$ is the assumed bias free connection level, beyond which the closure phase bias is negligible. $\\bar{C_n}$ is a complex number. By setting a threshold on both the amplitude and phase of $\\bar{C_n}$, we can obtain a proxy map for regions susceptible to the closure phase bias.\n",
-    "\n",
-    "Based on the network plot in [section 2.2](#2.2-Plot-the-interferogram-network) above, we know there are near-complete interferograms for connection level 1, 2, 3 and 28. Therefore, we choose connection-level-28 as the assumed bias free connection level, and use it for the detection calculation as below."
+    "where $C_n^k$ is the **sequential** closure phase with connection level-$n$ and starting at the $k$-th acquisition, e.g., $C_5^1 = \\Delta\\phi^{1,2} + \\Delta\\phi^{2,3} + \\Delta\\phi^{3,4} + \\Delta\\phi^{4,5} - \\Delta\\phi^{1,5}$. $K$ is the number of available sequential closure phase, $n$ is the assumed bias free connection level, beyond which the closure phase bias is negligible. $\\bar{C_n}$ is a complex number. By setting a threshold on both the amplitude and phase of $\\bar{C_n}$, we can obtain a proxy map for regions susceptible to the closure phase bias."
    ]
   },
   {
@@ -1529,7 +1577,7 @@
     "hidePrompt": false
    },
    "source": [
-    "### 3.2.5 Deramping (optional)"
+    "### 3.2.6 Deramping (optional)"
    ]
   },
   {
@@ -1562,7 +1610,7 @@
     "hidePrompt": false
    },
    "source": [
-    "### 3.2.6 Topographic residual (DEM error) correction"
+    "### 3.2.7 Topographic residual (DEM error) correction"
    ]
   },
   {
@@ -1640,7 +1688,7 @@
     "hidePrompt": false
    },
    "source": [
-    "### 3.2.7 Residual RMS for noise evaluation"
+    "### 3.2.8 Residual RMS for noise evaluation"
    ]
   },
   {
@@ -1653,6 +1701,10 @@
     "This step calculates the Root Mean Square (RMS) of the residual phase time-series for each acquisition; then it:\n",
     "1. selects the date with the minimum RMS value as the optimal reference date.\n",
     "2. detects the noisy acquisitions with RMS beyond the outlier detection threshold.\n",
+    "\n",
+    "<p align='left'>\n",
+    "    <img width=\"1000\" src=\"docs/rms_res_pha_yunjun19.jpg\">\n",
+    "</p>\n",
     "\n",
     "The corresponding template options are:\n",
     "```cfg\n",
@@ -1720,7 +1772,7 @@
     "hidePrompt": false
    },
    "source": [
-    "### 3.2.8 Changing the reference date"
+    "### 3.2.9 Changing the reference date"
    ]
   },
   {
@@ -1767,7 +1819,7 @@
     "hidePrompt": false
    },
    "source": [
-    "### 3.2.9 Re-estimating velocity after noise reduction"
+    "### 3.2.10 Re-estimating velocity after noise reduction"
    ]
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Introduce ionospheric delay correction into the smallbaselineApp_gmtsar tutorial, enrich workflow notebooks with new images and updated citations, renumber sections accordingly, and update README metadata

New Features:
- Add an ionospheric delay correction section with configuration examples and illustrative image to the smallbaselineApp_gmtsar workflow

Enhancements:
- Embed inline images for tropospheric correction, solid Earth tides, and RMS noise evaluation steps in the notebooks
- Renumber downstream notebook sections after inserting the ionospheric correction content
- Update solid Earth tides description to cite Xu & Sandwell (2020)
- Augment plate motion discussion with a Liu et al. (2025) reference

Documentation:
- Bump the README’s Python badge to 3.8+ and rename the EarthScope short course link label