### PR TITLE
update for 2026 gmtsar short course

### DIFF
--- a/workflows/smallbaselineApp_gmtsar.ipynb
+++ b/workflows/smallbaselineApp_gmtsar.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# InSAR Time Series Analysis: MintPy + GMTSAR products\n",
     "\n",
-    "**Author:** Zhang Yunjun, Heresh Fattahi, July 14-17, 2025 EarthScope InSAR short course with GMTSAR+.\n",
+    "**Author:** Zhang Yunjun, Heresh Fattahi, July 31 - August 4, 2026 EarthScope InSAR short course with GMTSAR+, Hohhot, Inner Mongolia.\n",
     "\n",
     "The Miami INsar Timeseries software in PYthon (MintPy) is an open-source package for InSAR time-series analysis. MintPy currently starts from stacks of unwrapped interferograms (in either geo- or radar-coordinates) and estimates ground displacement time-series. MintPy is primarily consistent with stacks of interferograms processed with ISCE. However, the software also supports interfarograms processed with other InSAR processors such as GAMMA, GMTSAR, SNAP and ROI_PAC. \n",
     "\n",
@@ -91,8 +91,11 @@
     "from mintpy.utils import readfile, utils as ut, plot as pp\n",
     "from mintpy.cli import view, tsview, plot_network, plot_transection\n",
     "from mintpy.view import prep_slice, plot_slice\n",
-    "import utils\n",
     "plt.rcParams.update({'font.size': 12})\n",
+    "\n",
+    "# grab the local notebook path\n",
+    "try: ipynb_dir\n",
+    "except NameError: ipynb_dir = os.getcwd()\n",
     "\n",
     "# utils function\n",
     "def write_config_file(out_file, CONFIG_TXT, mode='a'): \n",
@@ -733,7 +736,6 @@
     "hidden": true,
     "hideCode": false,
     "hidePrompt": false,
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],
@@ -859,7 +861,7 @@
    "source": [
     "%matplotlib widget\n",
     "# faults used in UCERF3 in GMT lonlat format. Use gmt to convert any KML file into GMT lonlat file, e.g. `gmt kml2gmt UCERF3_Fault.kml > UCERF3_Fault.lonlat`\n",
-    "fault_file = os.path.join(utils.get_local_path(), 'data/UCERF3_Fault.lonlat')\n",
+    "fault_file = os.path.join(ipynb_dir, 'data/UCERF3_Fault.lonlat')\n",
     "opt = f'--dem ./inputs/geometryGeo.h5 --shade-exag 0.05 --dem-nocontour --faultline {fault_file} --faultline-min-dist 10 -v -1 1 --lalo-label --ylabel-rot 90 --figsize 10 8'\n",
     "view.main(f'velocity.h5 velocity {opt}'.split())"
    ]
@@ -930,7 +932,7 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "view.main('velocity.h5 velocityStd -u mm -v 0 0.8'.split())"
+    "view.main('velocity.h5 velocityStd -u mm -v 0 0.8 --lalo-label'.split())"
    ]
   },
   {
@@ -1091,18 +1093,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# The line below generates a multi-choice selection box for the question above. It requires `ipywidgets`. If not working, just ignore this and continue.\n",
-    "utils.tcoh_vs_scoh"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "heading_collapsed": "true",
@@ -1185,18 +1175,6 @@
     "<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;C. Common mask from connected components\n",
     "<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;D. Water mask which indicates which pixel is water and which pixel is land\n",
     "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# The line below generates a multi-choice selection box for the question above. It requires `ipywidgets`. If not working, just ignore this and continue.\n",
-    "utils.inv_quality"
    ]
   },
   {
@@ -1387,7 +1365,48 @@
     "hidePrompt": false
    },
    "source": [
-    "### 3.2.1 Tropospheric delay correction"
+    "### 3.2.1 Solid Earth tides correction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "hideCode": false,
+    "hidePrompt": false
+   },
+   "source": [
+    "This step corrects the solid Earth tides ([Xu & Sandwell, 2020](https://doi.org/10.1109/TGRS.2019.2940207)) due to the gravity pull from the Sun and the Moon using [PySolid](https://github.com/insarlab/pysolid) ([Yunjun et al., 2022](https://ieeexplore.ieee.org/document/9759304)), which implements the IERS (International Earth Rotation and Reference Systems Service) 2010 Conventions ([Petit & Luzum, 2010](https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn36.html)).\n",
+    "\n",
+    "<p align='center'>\n",
+    "    <img width=\"800\" src=\"docs/set_yunjun22.png\">\n",
+    "</p>\n",
+    "\n",
+    "The corresponding template options are:\n",
+    "\n",
+    "```cfg\n",
+    "mintpy.solidEarthTides = auto #[yes / no], auto for no\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_config_file(config_file, \"mintpy.solidEarthTides = yes\")\n",
+    "!smallbaselineApp.py SanFranBaySenD42.txt --dostep correct_SET"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "heading_collapsed": "true",
+    "hideCode": false,
+    "hidePrompt": false
+   },
+   "source": [
+    "### 3.2.2 Tropospheric delay correction"
    ]
   },
   {
@@ -1443,7 +1462,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2.2 Ionospheric delay correction"
+    "### 3.2.3 Ionospheric delay correction"
    ]
   },
   {
@@ -1477,37 +1496,6 @@
     "Example `mintpy.load.ion*` values for:\n",
     "+ ISCE-2/topsStack: [link](https://github.com/insarlab/MintPy/blob/f7ac98f652908063fbdf3cbb1dfca11f822491b5/src/mintpy/defaults/auto_path.py#L26-L28)\n",
     "+ ISCE-2/alosStack: [link](https://github.com/insarlab/MintPy/blob/f7ac98f652908063fbdf3cbb1dfca11f822491b5/src/mintpy/defaults/auto_path.py#L68-L70)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "heading_collapsed": "true",
-    "hideCode": false,
-    "hidePrompt": false
-   },
-   "source": [
-    "### 3.2.3 Solid Earth tides correction"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "hideCode": false,
-    "hidePrompt": false
-   },
-   "source": [
-    "This step corrects the solid Earth tides ([Xu & Sandwell, 2020](https://doi.org/10.1109/TGRS.2019.2940207)) due to the gravity pull from the Sun and the Moon using [PySolid](https://github.com/insarlab/pysolid) ([Yunjun et al., 2022](https://ieeexplore.ieee.org/document/9759304)), which implements the IERS (International Earth Rotation and Reference Systems Service) 2010 Conventions ([Petit & Luzum, 2010](https://www.iers.org/IERS/EN/Publications/TechnicalNotes/tn36.html)).\n",
-    "\n",
-    "<p align='center'>\n",
-    "    <img width=\"800\" src=\"docs/set_yunjun22.png\">\n",
-    "</p>\n",
-    "\n",
-    "The corresponding template options are:\n",
-    "\n",
-    "```cfg\n",
-    "mintpy.solidEarthTides = auto #[yes / no], auto for no\n",
-    "```"
    ]
   },
   {


### PR DESCRIPTION
+ grab ipynb_dir within the notebook, instead of using utils.py file

+ remove 1) the call and imports of the utils.py as the ipywidget module is not really necessary

+ move the solid Earth tides correction to the front, to be consistent with smallbaselineApp

## Summary by Sourcery

Update GMTSAR smallbaselineApp notebook for the 2026 EarthScope short course, simplifying local data path handling and reordering correction steps.

Enhancements:
- Capture the notebook directory within the notebook itself and use it for local data file paths instead of relying on an external utils module.
- Reorder the solid Earth tides correction section to appear before tropospheric and ionospheric corrections, aligning with the smallbaselineApp workflow order.
- Adjust visualization options to include latitude/longitude labels for velocity standard deviation plots.

Documentation:
- Refresh course metadata in the notebook header for the 2026 EarthScope InSAR short course and update the ordering and description of correction subsections.

Chores:
- Remove unused utils imports, ipywidget-based helper cells, and related metadata settings from the notebook.